### PR TITLE
Use similar exceptions to php version

### DIFF
--- a/tests/test_uzireader.py
+++ b/tests/test_uzireader.py
@@ -8,7 +8,7 @@ from uzireader.exceptions import (
     UziException,
     UziExceptionServerConfigError,
     UziExceptionClientCertError,
-    UziCertException,
+    UziCertificateException,
 )
 from uzireader.uzipassuser import UziPassUser
 
@@ -59,11 +59,11 @@ class TestUziReader(unittest.TestCase):
 
     def test_check_cert_incorrect_san_data(self):
         self.checkCert("mock-005-incorrect-san-data.cert", "Incorrect SAN found",
-            UziCertException)
+            UziCertificateException)
 
     def test_check_cert_incorrect_san_data_2(self):
         self.checkCert("mock-006-incorrect-san-data.cert", "Incorrect SAN found",
-            UziCertException)
+            UziCertificateException)
 
     def test_check_valid_cert(self):
         cert = self.readCert("mock-011-correct.cert")

--- a/tests/test_uzireader.py
+++ b/tests/test_uzireader.py
@@ -64,7 +64,8 @@ class TestUziReader(unittest.TestCase):
 
     def test_check_cert_without_ia5_string(self):
         self.checkCert(
-            "mock-004-othername-without-ia5string.cert", UziCertificateNotUziException
+            "mock-004-othername-without-ia5string.cert",
+            exception=UziCertificateException,
         )
 
     def test_check_cert_incorrect_san_data(self):

--- a/tests/test_uzireader.py
+++ b/tests/test_uzireader.py
@@ -42,28 +42,44 @@ class TestUziReader(unittest.TestCase):
             UziPassUser(self.succ)
 
     def test_check_cert_without_valid_data(self):
-        self.checkCert("mock-001-no-valid-uzi-data.cert", "No valid UZI data found",
-            UziCertificateNotUziException)
+        self.checkCert(
+            "mock-001-no-valid-uzi-data.cert",
+            "No valid UZI data found",
+            UziCertificateNotUziException,
+        )
 
     def test_check_cert_with_invalid_san(self):
-        self.checkCert("mock-002-invalid-san.cert", "No valid UZI data found",
-            UziCertificateNotUziException)
+        self.checkCert(
+            "mock-002-invalid-san.cert",
+            "No valid UZI data found",
+            UziCertificateNotUziException,
+        )
 
     def test_check_cert_with_invalid_other_name(self):
-        self.checkCert("mock-003-invalid-othername.cert", "No valid UZI data found",
-            UziCertificateNotUziException)
+        self.checkCert(
+            "mock-003-invalid-othername.cert",
+            "No valid UZI data found",
+            UziCertificateNotUziException,
+        )
 
     def test_check_cert_without_ia5_string(self):
-        self.checkCert("mock-004-othername-without-ia5string.cert",
-            UziCertificateNotUziException)
+        self.checkCert(
+            "mock-004-othername-without-ia5string.cert", UziCertificateNotUziException
+        )
 
     def test_check_cert_incorrect_san_data(self):
-        self.checkCert("mock-005-incorrect-san-data.cert", "Incorrect SAN found",
-            UziCertificateException)
+        self.checkCert(
+            "mock-005-incorrect-san-data.cert",
+            "Incorrect SAN found",
+            UziCertificateException,
+        )
 
     def test_check_cert_incorrect_san_data_2(self):
-        self.checkCert("mock-006-incorrect-san-data.cert", "Incorrect SAN found",
-            UziCertificateException)
+        self.checkCert(
+            "mock-006-incorrect-san-data.cert",
+            "Incorrect SAN found",
+            UziCertificateException,
+        )
 
     def test_check_valid_cert(self):
         cert = self.readCert("mock-011-correct.cert")

--- a/tests/test_uzireader.py
+++ b/tests/test_uzireader.py
@@ -3,7 +3,13 @@ __author__ = "Rafael Dulfer <rafael.dulfer@gmail.com>"
 
 import os
 import unittest
-import uzireader.exceptions as exceptions
+from uzireader.exceptions import (
+    UziCertificateNotUziException,
+    UziException,
+    UziExceptionServerConfigError,
+    UziExceptionClientCertError,
+    UziCertException,
+)
 from uzireader.uzipassuser import UziPassUser
 
 
@@ -18,40 +24,46 @@ class TestUziReader(unittest.TestCase):
         f.close()
         return cert
 
-    def checkCert(self, path, message=None):
+    def checkCert(self, path, message=None, exception=UziException):
         cert = self.readCert(path)
-        with self.assertRaises(exceptions.UziException, msg=message):
+        with self.assertRaises(exception, msg=message):
             UziPassUser(self.succ, cert)
 
     def test_check_request_has_no_cert(self):
-        with self.assertRaises(exceptions.UziExceptionServerConfigError):
+        with self.assertRaises(UziExceptionServerConfigError):
             UziPassUser()
 
     def test_check_ssl_client_failed(self):
-        with self.assertRaises(exceptions.UziExceptionServerConfigError):
-            UziPassUser()
+        with self.assertRaises(UziExceptionServerConfigError):
+            UziPassUser(verify="failed")
 
     def test_check_no_client_cert(self):
-        with self.assertRaises(exceptions.UziExceptionClientCertError):
+        with self.assertRaises(UziExceptionClientCertError):
             UziPassUser(self.succ)
 
     def test_check_cert_without_valid_data(self):
-        self.checkCert("mock-001-no-valid-uzi-data.cert", "No valid UZI data found")
+        self.checkCert("mock-001-no-valid-uzi-data.cert", "No valid UZI data found",
+            UziCertificateNotUziException)
 
     def test_check_cert_with_invalid_san(self):
-        self.checkCert("mock-002-invalid-san.cert", "No valid UZI data found")
+        self.checkCert("mock-002-invalid-san.cert", "No valid UZI data found",
+            UziCertificateNotUziException)
 
     def test_check_cert_with_invalid_other_name(self):
-        self.checkCert("mock-003-invalid-othername.cert", "No valid UZI data found")
+        self.checkCert("mock-003-invalid-othername.cert", "No valid UZI data found",
+            UziCertificateNotUziException)
 
     def test_check_cert_without_ia5_string(self):
-        self.checkCert("mock-004-othername-without-ia5string.cert")
+        self.checkCert("mock-004-othername-without-ia5string.cert",
+            UziCertificateNotUziException)
 
     def test_check_cert_incorrect_san_data(self):
-        self.checkCert("mock-005-incorrect-san-data.cert", "Incorrect SAN found")
+        self.checkCert("mock-005-incorrect-san-data.cert", "Incorrect SAN found",
+            UziCertException)
 
     def test_check_cert_incorrect_san_data_2(self):
-        self.checkCert("mock-006-incorrect-san-data.cert", "Incorrect SAN found")
+        self.checkCert("mock-006-incorrect-san-data.cert", "Incorrect SAN found",
+            UziCertException)
 
     def test_check_valid_cert(self):
         cert = self.readCert("mock-011-correct.cert")

--- a/tests/test_uzivalidate.py
+++ b/tests/test_uzivalidate.py
@@ -44,26 +44,32 @@ class TestUziValidator(unittest.TestCase):
         user = UziPassUser(self.succ, cert)
         validator = UziPassValidator(True, [], [])
         user["OidCa"] = "1.2.3.4"
-        with self.assertRaises(UziCaException, msg="CA OID not UZI register Care Provider or named employee"):
+        with self.assertRaises(
+            UziCaException,
+            msg="CA OID not UZI register Care Provider or named employee",
+        ):
             validator.validate(user)
 
     def test_strict_ca(self):
         self.checkUser(
             "mock-007-strict-ca-check.cert",
             "CA OID not UZI register Care Provider or named employee",
-            exception=UziCaException
+            exception=UziCaException,
         )
 
     def test_incorrect_version(self):
-        self.checkUser("mock-008-invalid-version.cert", "UZI version not 1",
-            exception=UziVersionException)
+        self.checkUser(
+            "mock-008-invalid-version.cert",
+            "UZI version not 1",
+            exception=UziVersionException,
+        )
 
     def test_not_allowed_type(self):
         self.checkUser(
             "mock-009-invalid-types.cert",
             "UZI card type not allowed",
             [UZI_TYPE_CARE_PROVIDER],
-            exception=UziAllowedTypeException
+            exception=UziAllowedTypeException,
         )
 
     def test_not_allowed_role(self):
@@ -72,7 +78,7 @@ class TestUziValidator(unittest.TestCase):
             "UZI card role not allowed",
             ["N"],
             [UZI_ROLE_NURSE],
-            exception=UziAllowedRoleException
+            exception=UziAllowedRoleException,
         )
 
     def test_is_valid(self):

--- a/uzireader/consts.py
+++ b/uzireader/consts.py
@@ -4,10 +4,12 @@ OID_CA_CARE_PROVIDER = "2.16.528.1.1003.1.3.5.5.2"  # Reference page 59
 OID_CA_NAMED_EMPLOYEE = "2.16.528.1.1003.1.3.5.5.3"  # Reference page 59
 OID_CA_UNNAMED_EMPLOYEE = "2.16.528.1.1003.1.3.5.5.4"  # Reference page 59
 OID_CA_SERVER = "2.16.528.1.1003.1.3.5.5.5"  # Reference page 59
+
 UZI_TYPE_CARE_PROVIDER = "Z"  # Reference page 60
 UZI_TYPE_NAMED_EMPLOYEE = "N"  # Reference page 60
 UZI_TYPE_UNNAMED_EMPLOYEE = "M"  # Reference page 60
 UZI_TYPE_SERVER = "S"  # Reference page 60
+
 UZI_ROLE_PHARMACIST = "17."  # Reference page 89
 UZI_ROLE_DOCTOR = "01."  # Reference page 89
 UZI_ROLE_PHYSIOTHERAPIST = "04."  # Reference page 89
@@ -19,4 +21,5 @@ UZI_ROLE_NURSE = "30."  # Reference page 89
 UZI_ROLE_PHYS_ASSISTANT = "81."  # Reference page 89
 UZI_ROLE_ORTHOPEDAGOGUE_GENERALIST = "31."  # Reference page 89
 UZI_ROLE_CLINICAL_TECHNOLOGIST = "82."  # Reference page 89
+
 OID_IA5STRING = "2.5.5.5"  # https://oidref.com/2.5.5.5

--- a/uzireader/exceptions.py
+++ b/uzireader/exceptions.py
@@ -5,11 +5,15 @@ class UziException(Exception):
     """Base Exception for all Uzi Exceptions"""
 
 
-class UziExceptionServerConfigError(UziException):
+class UziCertException(UziException):
+    """Generic issue with a provided cert"""
+
+
+class UziExceptionServerConfigError(UziCertException):
     """Your webserver Did not pass the correct env"""
 
 
-class UziExceptionClientCertError(UziException):
+class UziExceptionClientCertError(UziCertException):
     """The client did not present a certificate"""
 
 
@@ -27,3 +31,7 @@ class UziVersionException(UziException):
 
 class UziCaException(UziException):
     """The client CA is invalid"""
+
+
+class UziCertificateNotUziException(UziException):
+    """Provided cert had no uzi data"""

--- a/uzireader/exceptions.py
+++ b/uzireader/exceptions.py
@@ -5,15 +5,15 @@ class UziException(Exception):
     """Base Exception for all Uzi Exceptions"""
 
 
-class UziCertException(UziException):
+class UziCertificateException(UziException):
     """Generic issue with a provided cert"""
 
 
-class UziExceptionServerConfigError(UziCertException):
+class UziExceptionServerConfigError(UziCertificateException):
     """Your webserver Did not pass the correct env"""
 
 
-class UziExceptionClientCertError(UziCertException):
+class UziExceptionClientCertError(UziCertificateException):
     """The client did not present a certificate"""
 
 

--- a/uzireader/exceptions.py
+++ b/uzireader/exceptions.py
@@ -11,3 +11,19 @@ class UziExceptionServerConfigError(UziException):
 
 class UziExceptionClientCertError(UziException):
     """The client did not present a certificate"""
+
+
+class UziAllowedRoleException(UziException):
+    """The client card role is not allowed"""
+
+
+class UziAllowedTypeException(UziException):
+    """The client card type is not allowed"""
+
+
+class UziVersionException(UziException):
+    """The client card version is wrong"""
+
+
+class UziCaException(UziException):
+    """The client CA is invalid"""

--- a/uzireader/uzipassuser.py
+++ b/uzireader/uzipassuser.py
@@ -7,7 +7,7 @@ from uzireader.exceptions import (
     UziException,
     UziExceptionServerConfigError,
     UziExceptionClientCertError,
-    UziCertException,
+    UziCertificateException,
     UziCertificateNotUziException,
 )
 from uzireader.consts import OID_IA5STRING
@@ -66,7 +66,7 @@ class UziPassUser(dict):
         """Attemps to parse the presented certificate and extract the user info
         from it"""
         if not self.cert.subject:
-            raise UziCertException("No subject rdnSequence")
+            raise UziCertificateException("No subject rdnSequence")
 
         givenName, surName = self._getName(self.cert.subject.rdns)
 
@@ -95,7 +95,7 @@ class UziPassUser(dict):
 
                 data = subjectAltName.split("-")
                 if len(data) < 6:
-                    raise UziCertException("Incorrect SAN found")
+                    raise UziCertificateException("Incorrect SAN found")
                 data[0] = data[0].split("?", 1)[1]
 
                 return {

--- a/uzireader/uzipassuser.py
+++ b/uzireader/uzipassuser.py
@@ -7,6 +7,8 @@ from uzireader.exceptions import (
     UziException,
     UziExceptionServerConfigError,
     UziExceptionClientCertError,
+    UziCertException,
+    UziCertificateNotUziException,
 )
 from uzireader.consts import OID_IA5STRING
 
@@ -64,7 +66,7 @@ class UziPassUser(dict):
         """Attemps to parse the presented certificate and extract the user info
         from it"""
         if not self.cert.subject:
-            raise UziException("No subject rdnSequence")
+            raise UziCertException("No subject rdnSequence")
 
         givenName, surName = self._getName(self.cert.subject.rdns)
 
@@ -93,7 +95,7 @@ class UziPassUser(dict):
 
                 data = subjectAltName.split("-")
                 if len(data) < 6:
-                    raise UziException("Incorrect SAN found")
+                    raise UziCertException("Incorrect SAN found")
                 data[0] = data[0].split("?", 1)[1]
 
                 return {
@@ -107,4 +109,4 @@ class UziPassUser(dict):
                     "Role": data[5],
                     "AgbCode": data[6],
                 }
-        raise UziException("No valid UZI data found")
+        raise UziCertificateNotUziException("No valid UZI data found")

--- a/uzireader/uzipassvalidator.py
+++ b/uzireader/uzipassvalidator.py
@@ -1,7 +1,7 @@
 __author__ = "Rafael Dulfer <rafael.dulfer@gmail.com>"
 
 from uzireader.consts import OID_CA_CARE_PROVIDER, OID_CA_NAMED_EMPLOYEE
-from uzireader.exceptions import UziException
+from uzireader.exceptions import UziException, UziCaException, UziVersionException, UziAllowedTypeException, UziAllowedRoleException
 from uzireader.uzipassuser import UziPassUser
 
 
@@ -27,12 +27,12 @@ class UziPassValidator:
             and oidca != OID_CA_CARE_PROVIDER
             and oidca != OID_CA_NAMED_EMPLOYEE
         ):
-            raise UziException(
+            raise UziCaException(
                 "CA OID not UZI register Care Provider or named employee"
             )
         if user["UziVersion"] != "1":
-            raise UziException("UZI version not 1")
+            raise UziVersionException("UZI version not 1")
         if user["CardType"] not in self.allowed_types:
-            raise UziException("UZI card type not allowed")
+            raise UziAllowedTypeException("UZI card type not allowed")
         if user["Role"][:3] not in self.allowed_roles:
-            raise UziException("UZI card role not allowed")
+            raise UziAllowedRoleException("UZI card role not allowed")

--- a/uzireader/uzipassvalidator.py
+++ b/uzireader/uzipassvalidator.py
@@ -1,7 +1,13 @@
 __author__ = "Rafael Dulfer <rafael.dulfer@gmail.com>"
 
 from uzireader.consts import OID_CA_CARE_PROVIDER, OID_CA_NAMED_EMPLOYEE
-from uzireader.exceptions import UziException, UziCaException, UziVersionException, UziAllowedTypeException, UziAllowedRoleException
+from uzireader.exceptions import (
+    UziException,
+    UziCaException,
+    UziVersionException,
+    UziAllowedTypeException,
+    UziAllowedRoleException,
+)
 from uzireader.uzipassuser import UziPassUser
 
 


### PR DESCRIPTION
For compatibility, this PR move most exceptions to those that are used by pUzi-php. 

The only difference now comes from the existence of the more specific exceptions `UziExceptionServerConfigError` and `UziExceptionClientCertError` (which in the PHP version are both simply `UziCertificateException`). I kept these specific exceptions because I think they're better than just using `UziCertificateException` everywhere, but they do inherit from `UziCertificateException` so there's still feature-parity.