### PR TITLE
script was hanging. Now reuses same private key for several mock certs

### DIFF
--- a/tests/certs/generate_mock_certs.sh
+++ b/tests/certs/generate_mock_certs.sh
@@ -1,95 +1,86 @@
 #!/bin/sh
 
+# Generates new key, we repeatedly use this key for the other certificates:
 openssl req -x509 \
-    -nodes \
+	  -newkey rsa:4096 \
     -keyout dummy.key \
     -out mock-001-no-valid-uzi-data.cert \
     -days 3650 \
+    -nodes \
     -subj "/C=NL/O=MockTest Cert/title=physician/SN=doe-12345678/GN=john/CN=john doe-12345678"
 
-openssl req -x509 \
-    -nodes \
-    -keyout dummy.key \
+openssl req -new -x509 \
+    -key dummy.key \
     -out mock-002-invalid-san.cert \
     -days 3650 \
     -subj "/C=NL/O=MockTest Cert/title=physician/SN=doe-12345678/GN=john/CN=john doe-12345678" \
     -addext "subjectAltName = DNS:foo.bar"
 
-openssl req -x509 \
-    -nodes \
-    -keyout dummy.key \
+openssl req -new -x509 \
+    -key dummy.key \
     -out mock-003-invalid-othername.cert \
     -days 3650 \
     -subj "/C=NL/O=MockTest Cert/title=physician/SN=doe-12345678/GN=john/CN=john doe-12345678" \
     -addext "subjectAltName = otherName:msUPN;UTF8:12345678@90000111"
 
-openssl req -x509 \
-    -nodes \
-    -keyout dummy.key \
+openssl req -new -x509 \
+    -key dummy.key \
     -out mock-004-othername-without-ia5string.cert \
     -days 3650 \
     -subj "/C=NL/O=MockTest Cert/title=physician/SN=doe-12345678/GN=john/CN=john doe-12345678" \
     -addext "subjectAltName = otherName:2.5.5.5;UTF8:12345678@90000111"
 
-openssl req -x509 \
-    -nodes \
-    -keyout dummy.key \
+openssl req -new -x509 \
+    -key dummy.key \
     -out mock-005-incorrect-san-data.cert \
     -days 3650 \
     -subj "/C=NL/O=MockTest Cert/title=physician/SN=doe-12345678/GN=john/CN=john doe-12345678" \
     -addext "subjectAltName = otherName:2.5.5.5;IA5STRING:12345678@90000111"
 
-openssl req -x509 \
-    -nodes \
-    -keyout dummy.key \
+openssl req -new -x509 \
+    -key dummy.key \
     -out mock-006-incorrect-san-data.cert \
     -days 3650 \
     -subj "/C=NL/O=MockTest Cert/title=physician/SN=doe-12345678/GN=john/CN=john doe-12345678" \
     -addext "subjectAltName = otherName:2.5.5.5;IA5STRING:14-41-44"
 
-openssl req -x509 \
-    -nodes \
-    -keyout dummy.key \
+openssl req -new -x509 \
+    -key dummy.key \
     -out mock-007-strict-ca-check.cert \
     -days 3650 \
     -subj "/C=NL/O=MockTest Cert/title=physician/SN=doe-12345678/GN=john/CN=john doe-12345678" \
     -addext "subjectAltName = otherName:2.5.5.5;IA5STRING:2.16.528.1.1003.1.3.5.5.1-1-12345678-Z-90000111-01.015-00000000"
 
-openssl req -x509 \
-    -nodes \
-    -keyout dummy.key \
+openssl req -new -x509 \
+    -key dummy.key \
     -out mock-008-invalid-version.cert \
     -days 3650 \
     -subj "/C=NL/O=MockTest Cert/title=physician/SN=doe-12345678/GN=john/CN=john doe-12345678" \
     -addext "subjectAltName = otherName:2.5.5.5;IA5STRING:2.16.528.1.1003.1.3.5.5.2-2-12345678-Z-90000111-01.015-00000000"
 
-openssl req -x509 \
-    -nodes \
-    -keyout dummy.key \
+openssl req -new -x509 \
+    -key dummy.key \
     -out mock-009-invalid-types.cert \
     -days 3650 \
     -subj "/C=NL/O=MockTest Cert/title=physician/SN=doe-12345678/GN=john/CN=john doe-12345678" \
     -addext "subjectAltName = otherName:2.5.5.5;IA5STRING:2.16.528.1.1003.1.3.5.5.2-1-12345678-K-90000111-01.015-00000000"
 
-openssl req -x509 \
-    -nodes \
-    -keyout dummy.key \
+openssl req -new -x509 \
+    -key dummy.key \
     -out mock-010-invalid-roles.cert \
     -days 3650 \
     -subj "/C=NL/O=MockTest Cert/title=physician/SN=doe-12345678/GN=john/CN=john doe-12345678" \
     -addext "subjectAltName = otherName:2.5.5.5;IA5STRING:2.16.528.1.1003.1.3.5.5.2-1-12345678-N-90000111-00.015-00000000"
 
-openssl req -x509 \
-    -nodes \
-    -keyout dummy.key \
+openssl req -new -x509 \
+    -key dummy.key \
     -out mock-011-correct.cert \
     -days 3650 \
     -subj "/C=NL/O=MockTest Cert/title=physician/SN=doe-12345678/GN=john/CN=john doe-12345678" \
     -addext "subjectAltName = otherName:2.5.5.5;IA5STRING:2.16.528.1.1003.1.3.5.5.2-1-12345678-N-90000111-30.015-00000000"
 
-openssl req -x509 \
-    -nodes \
-    -keyout dummy.key \
+openssl req -new -x509 \
+    -key dummy.key \
     -out mock-012-correct-admin.cert \
     -days 3650 \
     -subj "/C=NL/O=MockTest Cert/title=physician/SN=doe-11111111/GN=john/CN=john doe-11111111" \


### PR DESCRIPTION
The generate mock certs script was hanging for me, so I updated the script in such a way that it is now creates a dummy key on the first go, and starts reusing that dummy key for each consecutive certificate.