### PR TITLE
Bug fix voor verschillende type uzi passen

### DIFF
--- a/uzireader/uzipassuser.py
+++ b/uzireader/uzipassuser.py
@@ -108,7 +108,8 @@ class UziPassUser(dict):
                 if '=' in data[0]:
                     # To remove the \x16= prefix from the OidCa, for example \x16=2.16.528.1.1007.99.217
                     data[0] = data[0].split("=", 1)[1]
-                data[0] = data[0].split("?", 1)[1]
+                elif '?' in data[0]:
+                    data[0] = data[0].split("?", 1)[1]
 
                 return {
                     "givenName": givenName,


### PR DESCRIPTION
Ik dacht dat ik in het verleden het inloggen met de twee verschillende uzi passen (op naam, en niet op naam) al gefixt had. Maar er zit toch nog een foutje in, met deze PR lukt het wel om in te loggen met beide passen